### PR TITLE
Protect main branch from force push

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -28,6 +28,8 @@ github:
     squash:  true
     merge:   false
     rebase:  false
+  protected_branches:
+    main: {}
 
 publish:
   whoami: asf-site


### PR DESCRIPTION
We protect main branch from force push by modifying .asf.yaml, refer to https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-Branchprotection.