### PR TITLE
Enable issue to allow contributors to discuss features for website

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -19,7 +19,7 @@ github:
   description: "Apache Kvrocks Website"
   homepage: https://kvrocks.apache.org/
   features:
-    issues: false
+    issues: true
     projects: false
     wiki: false
   labels:


### PR DESCRIPTION
Some contributors would like to refactor the homepage for Kvrocks website and there's no way to discuss it now.