### PR TITLE
fix: dark footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -104,7 +104,7 @@ const config = {
         ],
       },
       footer: {
-        style: 'light',
+        style: 'dark',
         links: [
           {
             title: 'Docs',
@@ -153,9 +153,9 @@ const config = {
         },
         copyright: `<div style="text-align: left;">
           <div>
-            <p style="font-family: Avenir-Medium,serif;font-size: 14px;color: rgba(59, 61, 63, 1);line-height: 20px;"> Apache Kvrocks is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator. Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects. While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF. </p>
+            <p style="font-family: Avenir-Medium,serif;font-size: 14px;color: #999;line-height: 20px;"> Apache Kvrocks is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator. Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects. While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF. </p>
           </div>
-          <div style="border-top: 1px solid rgba(59, 61, 63, 1);min-height: 60px;line-height: 20px;text-align: center;font-family: Avenir-Medium,serif;font-size: 14px;color: rgba(59, 61, 63, 1);display: flex;align-items: center;"><span>Copyright © ${new Date().getFullYear()} The Apache Software Foundation. Apache Kvrocks, Kvrocks, and its feather logo are trademarks of The Apache Software Foundation.</span></div>
+          <div style="border-top: 1px solid #ccc;min-height: 60px;line-height: 20px;text-align: center;font-family: Avenir-Medium,serif;font-size: 14px;color: #999;display: flex;align-items: center;"><span>Copyright © ${new Date().getFullYear()} The Apache Software Foundation. Apache Kvrocks, Kvrocks, and its feather logo are trademarks of The Apache Software Foundation.</span></div>
         </div>`,
       },
       prism: {


### PR DESCRIPTION
Footer is normally in dark color mode. Revert related changes in #64.

Dark (proposed):

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/18818196/226646178-034c59eb-57d6-4c1a-8d5b-4dd773a86846.png">

Light (current):

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/18818196/226646266-4b4054bf-1834-4f1c-aed2-cce27a8a3fee.png">
