### PR TITLE
Remove the CDN path to fulfill apache website compliance

### DIFF
--- a/src/cdn.ts
+++ b/src/cdn.ts
@@ -3,11 +3,5 @@ export function resolveStaticAssetsURL(path: string) {
         path = '/' + path;
     }
 
-    if (process.env.NODE_ENV === 'development') {
-        return path;
-    }
-
-    // The DNS for cdn.jsdelivr.net and fastly.jsdelivr.net cannot be accessed from some regions.
-    // For now, gcore.jsdelivr.net is still accessible, but its future availability is uncertain.
-    return 'https://gcore.jsdelivr.net/gh/apache/incubator-kvrocks-website@main/static' + path;
+    return path
 }


### PR DESCRIPTION
Fix warning reports by Apache Podling Website Checker: https://whimsy.apache.org/pods/project/kvrocks

Those CDN links were introduced in PR #85 