### PR TITLE
User Key Encoding should use 8 bytes for versions.

### DIFF
--- a/community/data-structure-on-rocksdb.md
+++ b/community/data-structure-on-rocksdb.md
@@ -12,7 +12,7 @@ while the cluster slot determines its slot when cluster mode is enabled.
 ```text
 +-------------+-------------+------------------------------+-----------------+------------+-------------+-----------+
 |  ns size    |  namespace  |   cluster slot               |  user key size  |  user key  |   version   |  sub key  |
-| (1byte: X)  |   (Xbyte)   | (2byte when cluster enabled) |   (4byte: Y)    |   (YByte)  |    (4byte)  |   (ZByte) |
+| (1byte: X)  |   (Xbyte)   | (2byte when cluster enabled) |   (4byte: Y)    |   (YByte)  |   (8byte)   |  (ZByte)  |
 +-------------+-------------+------------------------------+-----------------+------------+-------------+-----------+
 ```
 


### PR DESCRIPTION
It's sourced from https://github.com/apache/incubator-kvrocks/blob/1dc5e9bb861ccc155996a1e5402553ca509da9d5/src/storage/redis_metadata.cc#L80-L105.